### PR TITLE
fix: Create base directory before Deno.openKv()

### DIFF
--- a/denops/@ddc-sources/deps/std.ts
+++ b/denops/@ddc-sources/deps/std.ts
@@ -1,1 +1,3 @@
 export { TextLineStream } from "https://deno.land/std@0.208.0/streams/mod.ts";
+export { dirname } from "https://deno.land/std@0.208.0/path/mod.ts";
+export { ensureDir } from "https://deno.land/std@0.208.0/fs/mod.ts";

--- a/denops/@ddc-sources/dictionary.ts
+++ b/denops/@ddc-sources/dictionary.ts
@@ -8,7 +8,7 @@ import {
   OnInitArguments,
   Previewer,
 } from "./deps/ddc.ts";
-import { TextLineStream } from "./deps/std.ts";
+import { dirname, ensureDir, TextLineStream } from "./deps/std.ts";
 import { Lock } from "./deps/async.ts";
 import Trie from "./lib/trie.ts";
 
@@ -54,6 +54,9 @@ export class Source extends BaseSource<Params> {
     sourceParams: params,
   }: OnInitArguments<Params>): Promise<void> {
     if (params.databasePath) {
+      const dir = dirname(params.databasePath);
+      // Deno.openKv throws when base directory doesn't exist
+      await ensureDir(dir);
       this.#db = await Deno.openKv(params.databasePath);
     }
   }


### PR DESCRIPTION
This change allows users to set a non-existent directory as the `databasePath` option.
